### PR TITLE
do not use CAR(...) as left hand side of assignment

### DIFF
--- a/inst/include/Rcpp/Context.h
+++ b/inst/include/Rcpp/Context.h
@@ -111,7 +111,7 @@ namespace Rcpp{
             PRIMFUN(ifun)(symb, ifun, args, R_GlobalEnv );
 
             // call it a second time to get the current R_HandlerStack
-            CAR(args) = R_NilValue ;
+            SETCAR(args, R_NilValue);
             SEXP value = PRIMFUN(ifun)(symb, ifun, args, R_GlobalEnv ) ;
             pair->second = VECTOR_ELT(CAR(value),4) ;
 


### PR DESCRIPTION
`CAR(x) = y;` relies on a particular implementation of the CAR macro, `SETCAR(x, y)` does not.
(and it is also properly checked, and works with reference counting)
